### PR TITLE
Require tag ownership for creating relayer.

### DIFF
--- a/packages/contracts/abi/contracts/ETSAccessControls.sol/ETSAccessControls.json
+++ b/packages/contracts/abi/contracts/ETSAccessControls.sol/ETSAccessControls.json
@@ -76,12 +76,6 @@
         "internalType": "address",
         "name": "relayer",
         "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isAdmin",
-        "type": "bool"
       }
     ],
     "name": "RelayerAdded",
@@ -97,7 +91,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggled",
+    "name": "RelayerLockToggled",
     "type": "event"
   },
   {
@@ -216,7 +210,7 @@
   },
   {
     "inputs": [],
-    "name": "RELAYER_ROLE",
+    "name": "RELAYER_ADMIN_ROLE",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -229,7 +223,20 @@
   },
   {
     "inputs": [],
-    "name": "RELAYER_ROLE_ADMIN",
+    "name": "RELAYER_FACTORY_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RELAYER_ROLE",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -257,16 +264,16 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_relayer",
+        "name": "_currentOwner",
         "type": "address"
       },
       {
-        "internalType": "string",
-        "name": "_name",
-        "type": "string"
+        "internalType": "address",
+        "name": "_newOwner",
+        "type": "address"
       }
     ],
-    "name": "addRelayer",
+    "name": "changeRelayerOwner",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -293,6 +300,25 @@
       }
     ],
     "name": "getRelayerAddressFromName",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "getRelayerAddressFromOwner",
     "outputs": [
       {
         "internalType": "address",
@@ -514,11 +540,49 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_addr",
         "type": "address"
       }
     ],
-    "name": "isRelayerPaused",
+    "name": "isRelayerByOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "isRelayerFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "isRelayerLocked",
     "outputs": [
       {
         "internalType": "bool",
@@ -549,6 +613,19 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayerOwner",
+        "type": "address"
+      }
+    ],
+    "name": "pauseRelayerByOwnerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "proxiableUUID",
     "outputs": [
@@ -559,6 +636,29 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayer",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "registerRelayer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -583,12 +683,50 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "relayerLocked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "",
         "type": "string"
       }
     ],
     "name": "relayerNameToContract",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "relayerOwnerToAddress",
     "outputs": [
       {
         "internalType": "address",
@@ -693,7 +831,7 @@
         "type": "address"
       }
     ],
-    "name": "toggleIsRelayerPaused",
+    "name": "toggleRelayerLock",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/contracts/abi/contracts/ETSRelayerFactory.sol/ETSRelayerFactory.json
+++ b/packages/contracts/abi/contracts/ETSRelayerFactory.sol/ETSRelayerFactory.json
@@ -55,7 +55,7 @@
     "outputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "relayer",
         "type": "address"
       }
     ],

--- a/packages/contracts/abi/contracts/interfaces/IETSAccessControls.sol/IETSAccessControls.json
+++ b/packages/contracts/abi/contracts/interfaces/IETSAccessControls.sol/IETSAccessControls.json
@@ -26,12 +26,6 @@
         "internalType": "address",
         "name": "relayer",
         "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isAdmin",
-        "type": "bool"
       }
     ],
     "name": "RelayerAdded",
@@ -47,7 +41,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggled",
+    "name": "RelayerLockToggled",
     "type": "event"
   },
   {
@@ -129,16 +123,16 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_relayer",
+        "name": "_currentOwner",
         "type": "address"
       },
       {
-        "internalType": "string",
-        "name": "_name",
-        "type": "string"
+        "internalType": "address",
+        "name": "_newOwner",
+        "type": "address"
       }
     ],
-    "name": "addRelayer",
+    "name": "changeRelayerOwner",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -165,6 +159,25 @@
       }
     ],
     "name": "getRelayerAddressFromName",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "getRelayerAddressFromOwner",
     "outputs": [
       {
         "internalType": "address",
@@ -377,6 +390,63 @@
         "type": "address"
       }
     ],
+    "name": "isRelayerByOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "isRelayerFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "isRelayerLocked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
     "name": "isSmartContract",
     "outputs": [
       {
@@ -386,6 +456,42 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayerOwner",
+        "type": "address"
+      }
+    ],
+    "name": "pauseRelayerByOwnerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayer",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "registerRelayer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -463,7 +569,7 @@
         "type": "address"
       }
     ],
-    "name": "toggleIsRelayerPaused",
+    "name": "toggleRelayerLock",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/contracts/abi/contracts/mocks/RelayerMock.sol/RelayerMock.json
+++ b/packages/contracts/abi/contracts/mocks/RelayerMock.sol/RelayerMock.json
@@ -72,7 +72,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerOwnerChanged",
+    "name": "RelayerLockToggledByOwner",
     "type": "event"
   },
   {
@@ -85,7 +85,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggledByOwner",
+    "name": "RelayerOwnerChanged",
     "type": "event"
   },
   {
@@ -328,7 +328,7 @@
   },
   {
     "inputs": [],
-    "name": "isPausedByOwner",
+    "name": "isPaused",
     "outputs": [
       {
         "internalType": "bool",

--- a/packages/contracts/abi/contracts/relayers/ETSRelayerV1.sol/ETSRelayerV1.json
+++ b/packages/contracts/abi/contracts/relayers/ETSRelayerV1.sol/ETSRelayerV1.json
@@ -59,7 +59,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerOwnerChanged",
+    "name": "RelayerLockToggledByOwner",
     "type": "event"
   },
   {
@@ -72,7 +72,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggledByOwner",
+    "name": "RelayerOwnerChanged",
     "type": "event"
   },
   {
@@ -244,6 +244,19 @@
   },
   {
     "inputs": [],
+    "name": "etsAccessControls",
+    "outputs": [
+      {
+        "internalType": "contract IETSAccessControls",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "etsTarget",
     "outputs": [
       {
@@ -349,6 +362,11 @@
         "type": "address"
       },
       {
+        "internalType": "contract IETSAccessControls",
+        "name": "_etsAccessControls",
+        "type": "address"
+      },
+      {
         "internalType": "address payable",
         "name": "_creator",
         "type": "address"
@@ -366,7 +384,7 @@
   },
   {
     "inputs": [],
-    "name": "isPausedByOwner",
+    "name": "isPaused",
     "outputs": [
       {
         "internalType": "bool",

--- a/packages/contracts/abi/contracts/relayers/interfaces/IETSRelayer.sol/IETSRelayer.json
+++ b/packages/contracts/abi/contracts/relayers/interfaces/IETSRelayer.sol/IETSRelayer.json
@@ -9,7 +9,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerOwnerChanged",
+    "name": "RelayerLockToggledByOwner",
     "type": "event"
   },
   {
@@ -22,7 +22,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggledByOwner",
+    "name": "RelayerOwnerChanged",
     "type": "event"
   },
   {
@@ -174,7 +174,7 @@
   },
   {
     "inputs": [],
-    "name": "isPausedByOwner",
+    "name": "isPaused",
     "outputs": [
       {
         "internalType": "bool",

--- a/packages/contracts/abi/contracts/test/ETSRelayerV2test.sol/ETSRelayerV2test.json
+++ b/packages/contracts/abi/contracts/test/ETSRelayerV2test.sol/ETSRelayerV2test.json
@@ -59,7 +59,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerOwnerChanged",
+    "name": "RelayerLockToggledByOwner",
     "type": "event"
   },
   {
@@ -72,7 +72,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggledByOwner",
+    "name": "RelayerOwnerChanged",
     "type": "event"
   },
   {
@@ -366,7 +366,7 @@
   },
   {
     "inputs": [],
-    "name": "isPausedByOwner",
+    "name": "isPaused",
     "outputs": [
       {
         "internalType": "bool",

--- a/packages/contracts/abi/contracts/test/UUPSTesting.sol/ETSAccessControlsUpgrade.json
+++ b/packages/contracts/abi/contracts/test/UUPSTesting.sol/ETSAccessControlsUpgrade.json
@@ -71,12 +71,6 @@
         "internalType": "address",
         "name": "relayer",
         "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isAdmin",
-        "type": "bool"
       }
     ],
     "name": "RelayerAdded",
@@ -92,7 +86,7 @@
         "type": "address"
       }
     ],
-    "name": "RelayerPauseToggled",
+    "name": "RelayerLockToggled",
     "type": "event"
   },
   {
@@ -211,7 +205,7 @@
   },
   {
     "inputs": [],
-    "name": "RELAYER_ROLE",
+    "name": "RELAYER_ADMIN_ROLE",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -224,7 +218,20 @@
   },
   {
     "inputs": [],
-    "name": "RELAYER_ROLE_ADMIN",
+    "name": "RELAYER_FACTORY_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RELAYER_ROLE",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -252,16 +259,16 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_relayer",
+        "name": "_currentOwner",
         "type": "address"
       },
       {
-        "internalType": "string",
-        "name": "_name",
-        "type": "string"
+        "internalType": "address",
+        "name": "_newOwner",
+        "type": "address"
       }
     ],
-    "name": "addRelayer",
+    "name": "changeRelayerOwner",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -288,6 +295,25 @@
       }
     ],
     "name": "getRelayerAddressFromName",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "getRelayerAddressFromOwner",
     "outputs": [
       {
         "internalType": "address",
@@ -509,11 +535,49 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_addr",
         "type": "address"
       }
     ],
-    "name": "isRelayerPaused",
+    "name": "isRelayerByOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "isRelayerFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "isRelayerLocked",
     "outputs": [
       {
         "internalType": "bool",
@@ -544,6 +608,19 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayerOwner",
+        "type": "address"
+      }
+    ],
+    "name": "pauseRelayerByOwnerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "proxiableUUID",
     "outputs": [
@@ -554,6 +631,29 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayer",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "registerRelayer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -578,12 +678,50 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "relayerLocked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "",
         "type": "string"
       }
     ],
     "name": "relayerNameToContract",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "relayerOwnerToAddress",
     "outputs": [
       {
         "internalType": "address",
@@ -688,7 +826,7 @@
         "type": "address"
       }
     ],
-    "name": "toggleIsRelayerPaused",
+    "name": "toggleRelayerLock",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/contracts/contracts/ETS.sol
+++ b/packages/contracts/contracts/ETS.sol
@@ -65,15 +65,14 @@ contract ETS is IETS, Initializable, ContextUpgradeable, ReentrancyGuardUpgradea
     }
 
     modifier onlyRelayer() {
-        require(etsAccessControls.isRelayerAndNotPaused(_msgSender()), "Caller not Relayer");
+        require(etsAccessControls.isRelayer(_msgSender()), "Caller not Relayer");
         _;
     }
 
     /// @dev Require that caller is original relayer or tagger.
     modifier onlyOriginalRelayerOrTagger(uint256 _taggingRecordId) {
         require(
-            (taggingRecords[_taggingRecordId].relayer == _msgSender() &&
-                etsAccessControls.isRelayerAndNotPaused(_msgSender())) ||
+            (taggingRecords[_taggingRecordId].relayer == _msgSender() && etsAccessControls.isRelayer(_msgSender())) ||
                 taggingRecords[_taggingRecordId].tagger == _msgSender(),
             "Not authorized"
         );

--- a/packages/contracts/contracts/ETSAccessControls.sol
+++ b/packages/contracts/contracts/ETSAccessControls.sol
@@ -8,8 +8,6 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { ERC165CheckerUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title IETSAccessControls
  * @author Ethereum Tag Service <team@ets.xyz>

--- a/packages/contracts/contracts/ETSToken.sol
+++ b/packages/contracts/contracts/ETSToken.sol
@@ -10,8 +10,6 @@ import { ERC721BurnableUpgradeable, ERC721Upgradeable, IERC165Upgradeable } from
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title ETSToken
  * @author Ethereum Tag Service <team@ets.xyz>

--- a/packages/contracts/contracts/ETSToken.sol
+++ b/packages/contracts/contracts/ETSToken.sol
@@ -10,6 +10,8 @@ import { ERC721BurnableUpgradeable, ERC721Upgradeable, IERC165Upgradeable } from
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title ETSToken
  * @author Ethereum Tag Service <team@ets.xyz>
@@ -354,6 +356,11 @@ contract ETSToken is
             } else {
                 _setLastRenewed(tokenId, block.timestamp);
             }
+        }
+
+        // If from address is not black hole or platform, and balance is going zero pause their relayer.
+        if (from != address(0) && from != getPlatformAddress() && balanceOf(from) == 0) {
+            etsAccessControls.pauseRelayerByOwnerAddress(from);
         }
     }
 

--- a/packages/contracts/contracts/interfaces/IETSAccessControls.sol
+++ b/packages/contracts/contracts/interfaces/IETSAccessControls.sol
@@ -27,16 +27,15 @@ interface IETSAccessControls is IAccessControlUpgradeable {
      * testing of ETS Core API fuinctions, ETS permits addition of ETS owned wallet addresses as Relayers.
      *
      * @param relayer Relayer contract address.
-     * @param isAdmin Relayer address is ETS administrator (used for testing).
      */
-    event RelayerAdded(address relayer, bool isAdmin);
+    event RelayerAdded(address relayer);
 
     /**
      * @dev emitted when a Relayer contract is paused or unpaused.
      *
      * @param relayer Address that had pause toggled.
      */
-    event RelayerPauseToggled(address relayer);
+    event RelayerLockToggled(address relayer);
 
     /**
      * @notice Sets the Platform wallet address. Can only be called by address with DEFAULT_ADMIN_ROLE.
@@ -51,8 +50,25 @@ interface IETSAccessControls is IAccessControlUpgradeable {
      *
      * @param _relayer Address of the Relayer contract. Must conform to IETSRelayer.
      * @param _name Human readable name of the Relayer.
+     * @param _owner Address of relayer owner.
      */
-    function addRelayer(address _relayer, string calldata _name) external;
+    function registerRelayer(address _relayer, string calldata _name, address _owner) external;
+
+    /**
+     * @notice Pause relayer given the relayer owner address. Callable by Platform only.
+     *
+     * @param _relayerOwner Address of the Relayer owner.
+     */
+    function pauseRelayerByOwnerAddress(address _relayerOwner) external;
+
+    /**
+     * @notice Change the relayer owner as stored in ETSAccessControls. Callable from Relayer only.
+     * Called via changeOwner() on a relayer.
+     *
+     * @param _currentOwner Address of the current relayer owner.
+     * @param _newOwner Address of the new relayer owner.
+     */
+    function changeRelayerOwner(address _currentOwner, address _newOwner) external;
 
     /**
      * @notice Pauses/Unpauses a Relayer contract. Can only be called by address
@@ -60,7 +76,7 @@ interface IETSAccessControls is IAccessControlUpgradeable {
      *
      * @param _relayer Address of the Relayer contract.
      */
-    function toggleIsRelayerPaused(address _relayer) external;
+    function toggleRelayerLock(address _relayer) external;
 
     /**
      * @notice Sets the role admin for a given role. An address with role admin can grant or
@@ -88,12 +104,44 @@ interface IETSAccessControls is IAccessControlUpgradeable {
     function isAdmin(address _addr) external view returns (bool);
 
     /**
-     * @notice Checks whether given address has RELAYER role.
+     * @notice Checks whether given address can act as relayer factory.
      *
      * @param _addr Address being checked.
-     * @return boolean True if address has RELAYER role.
+     * @return boolean True if address can act as relayer factory.
+     */
+    function isRelayerFactory(address _addr) external view returns (bool);
+
+    /**
+     * @notice Checks whether given address is a relayer.
+     *
+     * @param _addr Address being checked.
+     * @return boolean True if address can be a relayer.
      */
     function isRelayer(address _addr) external view returns (bool);
+
+    /**
+     * @notice Checks whether given address is a registered Relayer and not paused.
+     *
+     * @param _addr Address being checked.
+     * @return boolean True if address is a Relayer and not paused.
+     */
+    function isRelayerAndNotPaused(address _addr) external view returns (bool);
+
+    /**
+     * @notice Checks relayer is paused by ETS Platform.
+     *
+     * @param _addr Address being checked.
+     * @return boolean True if relayer address is paused by platform.
+     */
+    function isRelayerLocked(address _addr) external view returns (bool);
+
+    /**
+     * @notice Checks whether given address owns a relayer.
+     *
+     * @param _addr Address being checked.
+     * @return boolean True if address owns a relayer.
+     */
+    function isRelayerByOwner(address _addr) external view returns (bool);
 
     /**
      * @notice Checks whether given address has RELAYER_ADMIN role.
@@ -120,14 +168,6 @@ interface IETSAccessControls is IAccessControlUpgradeable {
     function isRelayerByAddress(address _addr) external view returns (bool);
 
     /**
-     * @notice Checks whether given address is a registered Relayer and not paused.
-     *
-     * @param _addr Address being checked.
-     * @return boolean True if address is a Relayer and not paused.
-     */
-    function isRelayerAndNotPaused(address _addr) external view returns (bool);
-
-    /**
      * @notice Get relayer address from it's name.
      *
      * @param _name Name of relayer.
@@ -142,6 +182,14 @@ interface IETSAccessControls is IAccessControlUpgradeable {
      * @return Name of relayer.
      */
     function getRelayerNameFromAddress(address _address) external view returns (string calldata);
+
+    /**
+     * @notice Get relayer address from its owner address.
+     *
+     * @param _address address of relayer owner.
+     * @return Address of relayer.
+     */
+    function getRelayerAddressFromOwner(address _address) external view returns (address);
 
     /**
      * @notice Returns wallet address for ETS Platform.

--- a/packages/contracts/contracts/mocks/RelayerMock.sol
+++ b/packages/contracts/contracts/mocks/RelayerMock.sol
@@ -77,7 +77,7 @@ contract RelayerMock is ERC165, IETSRelayer, Ownable, Pausable {
         return interfaceId == IID_IETSRELAYER || super.supportsInterface(interfaceId);
     }
 
-    function isPausedByOwner() public view returns (bool) {}
+    function isPaused() public view returns (bool) {}
 
     function getRelayerName() public pure returns (string memory) {
         return NAME;

--- a/packages/contracts/contracts/relayers/interfaces/IETSRelayer.sol
+++ b/packages/contracts/contracts/relayers/interfaces/IETSRelayer.sol
@@ -18,7 +18,7 @@ interface IETSRelayer {
      *
      * @param relayerAddress Address of relayer contract.
      */
-    event RelayerPauseToggledByOwner(address relayerAddress);
+    event RelayerLockToggledByOwner(address relayerAddress);
 
     /**
      * @dev Emitted when an IETSRelayer contract has changed owners.
@@ -69,7 +69,7 @@ interface IETSRelayer {
      * @dev Pause functionality should be provided by OpenZeppelin Pausable utility.
      * @return boolean: true for paused; false for not paused.
      */
-    function isPausedByOwner() external view returns (bool);
+    function isPaused() external view returns (bool);
 
     /**
      * @notice Returns address of an IETSRelayer contract owner.

--- a/packages/contracts/contracts/test/ETSRelayerV2test.sol
+++ b/packages/contracts/contracts/test/ETSRelayerV2test.sol
@@ -83,13 +83,13 @@ contract ETSRelayerV2test is
     /// @inheritdoc IETSRelayer
     function pause() public onlyOwner {
         _pause();
-        emit RelayerPauseToggledByOwner(address(this));
+        emit RelayerLockToggledByOwner(address(this));
     }
 
     /// @inheritdoc IETSRelayer
     function unpause() public onlyOwner {
         _unpause();
-        emit RelayerPauseToggledByOwner(address(this));
+        emit RelayerLockToggledByOwner(address(this));
     }
 
     /// @inheritdoc IETSRelayer
@@ -150,7 +150,7 @@ contract ETSRelayerV2test is
     }
 
     /// @inheritdoc IETSRelayer
-    function isPausedByOwner() public view virtual returns (bool) {
+    function isPaused() public view virtual returns (bool) {
         return paused();
     }
 

--- a/packages/contracts/test/ETS.test.js
+++ b/packages/contracts/test/ETS.test.js
@@ -20,10 +20,10 @@ describe("ETS Core tests", function () {
     // Add & unpause ETSPlatform EOA as a Relayer. Using a wallet address as a relayer
     // is only for testing all ETS core public functions that don't necessarily need to be
     // included in a proper relayer (IETSRelayer) contract
-    await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-      accounts.ETSPlatform.address,
-      "ETSPlatform",
-    );
+    // await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
+    //   accounts.ETSPlatform.address,
+    //   "ETSPlatform",
+    // );
 
     // Mint some tags via ETSRelayer. Creator is Creator. Retained by platform.
     await contracts.ETSRelayer.connect(accounts.Creator).getOrCreateTagIds([tagstring1]);
@@ -66,13 +66,13 @@ describe("ETS Core tests", function () {
       expect(await contracts.ETS.etsTarget()).to.be.equal(contracts.ETSTarget.address);
     });
     it("should have an active relayer contract (ETSRelayer)", async () => {
-
       expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(contracts.ETSRelayer.address)).to.be.equal(
         true,
       );
     });
+
     it("should have a testing relayer (ETSPlatform)", async () => {
-      expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(accounts.ETSPlatform.address)).to.be.equal(true);
+      expect(await contracts.ETSAccessControls.isRelayer(accounts.ETSPlatform.address)).to.be.equal(true);
     });
   });
 
@@ -1227,7 +1227,7 @@ describe("ETS Core tests", function () {
       );
 
       // Pause ETSRelayer
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(
         contracts.ETSRelayer.address,
       );
 

--- a/packages/contracts/test/ETSAccessControls.test.js
+++ b/packages/contracts/test/ETSAccessControls.test.js
@@ -8,34 +8,47 @@ describe("ETSAccessControls Tests", function () {
 
     // ETSRelayer is deployed globally for all tests,
     // so let's deploy a mock for testing access controls.
-    RelayerMock = await ethers.getContractFactory("RelayerMock", accounts.RandomOne);
-    relayerMock = await RelayerMock.deploy(
-      contracts.ETS.address,
-      contracts.ETSToken.address,
-      contracts.ETSTarget.address,
-      accounts.RandomOne.address, // creator
-      accounts.RandomTwo.address, // transfer to (new owner)
-    );
+    //RelayerMock = await ethers.getContractFactory("RelayerMock", accounts.RandomOne);
+    //relayerMock = await RelayerMock.deploy(
+    //  contracts.ETS.address,
+    //  contracts.ETSToken.address,
+    //  contracts.ETSTarget.address,
+    //  accounts.RandomOne.address, // creator
+    //  accounts.RandomTwo.address, // transfer to (new owner)
+    //);
   });
 
   describe("Valid setup/initialization", async function () {
-    it("grants ETSAdmin (deployer) the DEFAULT_ADMIN_ROLE role", async function () {
-      expect(await contracts.ETSAccessControls.isAdmin(accounts.ETSAdmin.address)).to.be.equal(true);
+
+    it("sets RELAYER_ADMIN_ROLE as the role that can grant RELAYER_FACTORY_ROLE.", async () => {
+      expect(await contracts.ETSAccessControls.getRoleAdmin(ethers.utils.id("RELAYER_FACTORY_ROLE"))).to.be.equal(
+        await ethers.utils.id("RELAYER_ADMIN_ROLE"),
+      );
     });
 
-    it('sets ETSPlatform address as the "Platform"', async () => {
-      expect(await contracts.ETSAccessControls.getPlatformAddress()).to.be.equal(accounts.ETSPlatform.address);
+    it("sets RELAYER_FACTORY_ROLE as the role that can grant RELAYER_ROLE.", async () => {
+      expect(await contracts.ETSAccessControls.getRoleAdmin(ethers.utils.id("RELAYER_ROLE"))).to.be.equal(
+        await ethers.utils.id("RELAYER_FACTORY_ROLE"),
+      );
+    });
+
+    it("grants ETSAdmin (deployer) the DEFAULT_ADMIN_ROLE role", async function () {
+      expect(await contracts.ETSAccessControls.isAdmin(accounts.ETSAdmin.address)).to.be.equal(true);
     });
 
     it("grants ETSPlatform the DEFAULT_ADMIN_ROLE", async function () {
       expect(await contracts.ETSAccessControls.isAdmin(accounts.ETSPlatform.address)).to.be.equal(true);
     });
 
-    it("sets RELAYER_ADMIN as the role that can administer RELAYER role.", async () => {
-      expect(await contracts.ETSAccessControls.getRoleAdmin(ethers.utils.id("RELAYER"))).to.be.equal(
-        await ethers.utils.id("RELAYER_ADMIN"),
-      );
+    it('sets ETSPlatform address as the "Platform"', async () => {
+      expect(await contracts.ETSAccessControls.getPlatformAddress()).to.be.equal(accounts.ETSPlatform.address);
     });
+
+    it("grants ETSPlatform the RELAYER_ADMIN_ROLE", async function () {
+      expect(await contracts.ETSAccessControls.isRelayerAdmin(accounts.ETSPlatform.address)).to.be.equal(true);
+    });
+
+
   });
 
   describe("Platform address", async function () {
@@ -45,132 +58,6 @@ describe("ETSAccessControls Tests", function () {
 
       await contracts.ETSAccessControls.connect(accounts.ETSPlatform).setPlatform(accounts.RandomOne.address);
       expect(await contracts.ETSAccessControls.getPlatformAddress()).to.be.equal(accounts.RandomOne.address);
-    });
-  });
-
-  describe("New relayers", async function () {
-    it("can only be added by RELAYER_ROLE_ADMIN role.", async () => {
-      // accounts.RandomOne tries to add Relayer.
-      await expect(
-        contracts.ETSAccessControls.connect(accounts.RandomOne).addRelayer(
-          relayerMock.address,
-          await relayerMock.getRelayerName(),
-        ),
-      ).to.be.reverted;
-
-      const tx = await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-        relayerMock.address,
-        await relayerMock.getRelayerName(),
-      );
-      await expect(tx).to.emit(contracts.ETSAccessControls, "RelayerAdded").withArgs(relayerMock.address, false);
-    });
-
-    it("can be a wallet address if that address has ETSAdministrator role", async () => {
-      // Having a wallet as a relayer is ONLY for making testing core functions easier.
-      await expect(
-        contracts.ETSAccessControls.connect(accounts.RandomOne).addRelayer(accounts.RandomOne.address, "RandomOne"),
-      ).to.be.reverted;
-
-      // RandomOne wallet MUST have RELAYER_ROLE_ADMIN in order to be added as relayer.
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).grantRole(
-        await contracts.ETSAccessControls.RELAYER_ROLE_ADMIN(),
-        accounts.RandomOne.address,
-      );
-
-      // RandomOne adds itself as a relayer.
-      const tx = await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-        accounts.RandomOne.address,
-        "RandomOne",
-      );
-      await expect(tx)
-        .to.emit(contracts.ETSAccessControls, "RelayerAdded")
-        .withArgs(accounts.RandomOne.address, true);
-    });
-
-    it("are not paused when added", async () => {
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-        relayerMock.address,
-        await relayerMock.getRelayerName(),
-      );
-
-      expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(relayerMock.address)).to.be.equal(true);
-    });
-
-    it("must implement IETSRelayer interface.", async () => {
-      // Trying to add wallet address as relayer.
-      await expect(
-        contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(accounts.RandomOne.address, "Random"),
-      ).to.be.reverted;
-    });
-
-    it("must have unique address.", async () => {
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-        relayerMock.address,
-        await relayerMock.getRelayerName(),
-      );
-
-      await expect(
-        contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-          relayerMock.address,
-          "Duplicate address",
-        ),
-      ).to.be.revertedWith("Relayer exists");
-    });
-
-    it("can be paused/unpaused by Administrator", async () => {
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-        relayerMock.address,
-        await relayerMock.getRelayerName(),
-      );
-      // Try unpausing by non-administrator account.
-      await expect(
-        contracts.ETSAccessControls.connect(accounts.RandomOne).toggleIsRelayerPaused(relayerMock.address),
-      ).to.be.reverted;
-
-      await expect(
-        contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(relayerMock.address),
-      )
-        .to.emit(contracts.ETSAccessControls, "RelayerPauseToggled")
-        .withArgs(relayerMock.address);
-
-      expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(relayerMock.address)).to.be.equal(false);
-
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(relayerMock.address);
-      expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(relayerMock.address)).to.be.equal(true);
-    });
-  });
-
-  describe("Active relayer contracts", async () => {
-    beforeEach("Setup test", async () => {
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-        relayerMock.address,
-        "RelayerMock",
-      );
-    });
-    it("can be verified by address", async () => {
-      expect(await contracts.ETSAccessControls.isRelayerByAddress(relayerMock.address)).to.be.equal(true);
-      expect(await contracts.ETSAccessControls.isRelayer(relayerMock.address)).to.be.equal(true);
-    });
-    it("can be verified by name", async () => {
-      expect(await contracts.ETSAccessControls.isRelayerByName("RelayerMock")).to.be.equal(true);
-    });
-    it("can be paused & unpaused by Owner", async () => {
-      expect(await relayerMock.paused()).to.be.equal(false);
-      expect(await relayerMock.isPausedByOwner()).to.be.equal(false);
-
-      // Try pausing as non-owner (eg. ETSPlatform)
-      await expect(relayerMock.connect(accounts.ETSPlatform).pause()).to.be.revertedWith(
-        "Ownable: caller is not the owner",
-      );
-
-      // Now pause as the owner
-      await expect(relayerMock.connect(accounts.RandomTwo).pause())
-        .to.emit(relayerMock, "Paused")
-        .withArgs(accounts.RandomTwo.address);
-
-      await expect(relayerMock.connect(accounts.RandomTwo).unpause())
-        .to.emit(relayerMock, "Unpaused")
-        .withArgs(accounts.RandomTwo.address);
     });
   });
 });

--- a/packages/contracts/test/ETSAuctionHouse.test.js
+++ b/packages/contracts/test/ETSAuctionHouse.test.js
@@ -17,16 +17,6 @@ describe("ETS Auction House Tests", function () {
   beforeEach("Setup test", async function () {
     [accounts, contracts, initSettings] = await setup();
 
-    // Add & unpause ETSPlatform as a Relayer.
-    await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-      accounts.ETSPlatform.address,
-      "ETSPlatform",
-    );
-
-    //await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(
-    //  accounts.ETSPlatform.address,
-    //);
-
     // Mint a tag by random user. ETS is Relayer, retained by platform.
     etsOwnedTag = "#Love";
     await contracts.ETS.connect(accounts.ETSPlatform).createTag(etsOwnedTag, accounts.RandomTwo.address);

--- a/packages/contracts/test/ETSRelayer.test.js
+++ b/packages/contracts/test/ETSRelayer.test.js
@@ -52,7 +52,7 @@ describe("ETS Relayer Tests", function () {
         true,
       );
       // Pause ETSRelayer
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(
         contracts.ETSRelayer.address,
       );
 
@@ -121,7 +121,7 @@ describe("ETS Relayer Tests", function () {
       });
 
       // Pause ETSRelayer
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(
         contracts.ETSRelayer.address,
       );
       await expect(contracts.ETSRelayer.connect(accounts.RandomOne).removeTags(taggingRecords)).to.be.revertedWith(
@@ -196,7 +196,7 @@ describe("ETS Relayer Tests", function () {
       });
 
       // Pause ETSRelayer
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(
         contracts.ETSRelayer.address,
       );
 
@@ -333,7 +333,7 @@ describe("ETS Relayer Tests", function () {
       });
 
       // Pause ETSRelayer
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(
         contracts.ETSRelayer.address,
       );
 

--- a/packages/contracts/test/ETSRelayerFactory.test.js
+++ b/packages/contracts/test/ETSRelayerFactory.test.js
@@ -5,26 +5,6 @@ const { expect } = require("chai");
 describe("ETSRelayerFactory Tests", function () {
   beforeEach("Setup test", async function () {
     [accounts, contracts, initSettings] = await setup();
-
-    // In these tests, adding a relayer is done by a random user (randomOne), so that user must own a CTAG.
-    // Create a tag and transfer it to RandomOne
-    const tag = "#LOVE";
-    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag]);
-    tokenId = await contracts.ETSToken.computeTagId(tag);
-    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
-      accounts.ETSPlatform.address,
-      accounts.RandomOne.address,
-      tokenId,
-    );
-
-    const tag2 = "#HATE";
-    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag2]);
-    tokenId2 = await contracts.ETSToken.computeTagId(tag2);
-    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
-      accounts.ETSPlatform.address,
-      accounts.RandomOne.address,
-      tokenId2,
-    );
   });
 
   describe("Valid setup/initialization", async function () {

--- a/packages/contracts/test/ETSRelayerFactory.test.js
+++ b/packages/contracts/test/ETSRelayerFactory.test.js
@@ -5,33 +5,51 @@ const { expect } = require("chai");
 describe("ETSRelayerFactory Tests", function () {
   beforeEach("Setup test", async function () {
     [accounts, contracts, initSettings] = await setup();
+
+    // In these tests, adding a relayer is done by a random user (randomOne), so that user must own a CTAG.
+    // Create a tag and transfer it to RandomOne
+    const tag = "#LOVE";
+    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag]);
+    tokenId = await contracts.ETSToken.computeTagId(tag);
+    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+      accounts.ETSPlatform.address,
+      accounts.RandomOne.address,
+      tokenId,
+    );
+
+    const tag2 = "#HATE";
+    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag2]);
+    tokenId2 = await contracts.ETSToken.computeTagId(tag2);
+    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+      accounts.ETSPlatform.address,
+      accounts.RandomOne.address,
+      tokenId2,
+    );
   });
 
   describe("Valid setup/initialization", async function () {
-    it("sets RELAYER_ADMIN as the role that can administer RELAYER role.", async () => {
-      expect(await contracts.ETSAccessControls.getRoleAdmin(ethers.utils.id("RELAYER"))).to.be.equal(
-        await ethers.utils.id("RELAYER_ADMIN"),
+    it("sets RELAYER_ADMIN_ROLE as the role that can administer RELAYER_ROLE role.", async () => {
+      expect(await contracts.ETSAccessControls.getRoleAdmin(ethers.utils.id("RELAYER_ROLE"))).to.be.equal(
+        await ethers.utils.id("RELAYER_FACTORY_ROLE"),
       );
     });
 
-    it("grants ETSRelayerFactory the RELAYER_ADMIN role", async function () {
-      expect(await contracts.ETSAccessControls.isRelayerAdmin(contracts.ETSRelayerFactory.address)).to.be.equal(
-        true,
-      );
+    it("Enables ETSRelayerFactory as a relayer factory.", async function () {
+      expect(await contracts.ETSAccessControls.isRelayerFactory(contracts.ETSRelayerFactory.address)).to.be.equal(true);
     });
   });
 
   describe("New relayers", async function () {
-    it("can only be added by factory with RELAYER_ROLE_ADMIN role.", async () => {
+    it("can only be added by if factory has correct role.", async () => {
       await contracts.ETSAccessControls.connect(accounts.ETSPlatform).revokeRole(
-        ethers.utils.id("RELAYER_ADMIN"),
+        ethers.utils.id("RELAYER_FACTORY_ROLE"),
         contracts.ETSRelayerFactory.address,
       );
 
       await expect(contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap")).to.be.reverted;
 
       await contracts.ETSAccessControls.connect(accounts.ETSPlatform).grantRole(
-        ethers.utils.id("RELAYER_ADMIN"),
+        ethers.utils.id("RELAYER_FACTORY_ROLE"),
         contracts.ETSRelayerFactory.address,
       );
 
@@ -39,13 +57,40 @@ describe("ETSRelayerFactory Tests", function () {
       await expect(tx).to.emit(contracts.ETSAccessControls, "RelayerAdded");
     });
 
-    it("Revert if name is too short", async () => {
+    it("can only be added if sender owns a CTAG.", async () => {
+      await contracts.ETSToken.connect(accounts.RandomOne).transferFrom(
+        accounts.RandomOne.address,
+        accounts.ETSPlatform.address,
+        tokenId,
+      );
+
+      await contracts.ETSToken.connect(accounts.RandomOne).transferFrom(
+        accounts.RandomOne.address,
+        accounts.ETSPlatform.address,
+        tokenId2,
+      );
+
+      await expect(contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap")).to.be.revertedWith(
+        "Must own CTAG",
+      );
+
+      await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+        accounts.ETSPlatform.address,
+        accounts.RandomOne.address,
+        tokenId,
+      );
+
+      const tx = await contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap");
+      await expect(tx).to.emit(contracts.ETSAccessControls, "RelayerAdded");
+    });
+
+    it("will revert if name is too short", async () => {
       await expect(contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("X")).to.be.revertedWith(
         "Relayer name too short",
       );
     });
 
-    it("Revert if name is too long", async () => {
+    it("will revert if name is too long", async () => {
       await expect(
         contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer(
           "this is a relayer name that is well well well well over the limit in length",
@@ -53,12 +98,12 @@ describe("ETSRelayerFactory Tests", function () {
       ).to.be.revertedWith("Relayer name too long");
     });
 
-    it("Revert if name already exists", async () => {
+    it("will revert if name already exists", async () => {
       await contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap");
 
-      await expect(
-        contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap"),
-      ).to.be.revertedWith("Relayer name exists");
+      await expect(contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap")).to.be.revertedWith(
+        "Relayer name exists",
+      );
     });
 
     it("will emit RelayerAdded", async () => {
@@ -71,28 +116,10 @@ describe("ETSRelayerFactory Tests", function () {
       const relayerAddress = contracts.ETSAccessControls.getRelayerAddressFromName("Uniswap");
       expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(relayerAddress)).to.be.equal(true);
     });
-
-    it("can be paused/unpaused by Administrator", async () => {
-      await contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap");
-
-      // Try pausing by non-administrator account.
-      const relayerAddress = await contracts.ETSAccessControls.getRelayerAddressFromName("Uniswap");
-      await expect(contracts.ETSAccessControls.connect(accounts.RandomOne).toggleIsRelayerPaused(relayerAddress)).to
-        .be.reverted;
-
-      await expect(contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(relayerAddress))
-        .to.emit(contracts.ETSAccessControls, "RelayerPauseToggled")
-        .withArgs(relayerAddress);
-
-      expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(relayerAddress)).to.be.equal(false);
-
-      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleIsRelayerPaused(relayerAddress);
-      expect(await contracts.ETSAccessControls.isRelayerAndNotPaused(relayerAddress)).to.be.equal(true);
-    });
   });
 
   describe("Active relayer contracts", async () => {
-    beforeEach("Setup test", async () => {
+    beforeEach("Setup active relayer tests", async () => {
       await contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Uniswap");
       relayerAddress = await contracts.ETSAccessControls.getRelayerAddressFromName("Uniswap");
       etsRelayerV1ABI = require("../abi/contracts/relayers/ETSRelayerV1.sol/ETSRelayerV1.json");
@@ -100,18 +127,45 @@ describe("ETSRelayerFactory Tests", function () {
       uniswapRelayer = new ethers.Contract(relayerAddress, etsRelayerV1ABI, accounts.RandomOne);
     });
 
-    it("can be verified by address", async () => {
+    it("can be looked up by address", async () => {
       expect(await contracts.ETSAccessControls.isRelayerByAddress(relayerAddress)).to.be.equal(true);
       expect(await contracts.ETSAccessControls.isRelayer(relayerAddress)).to.be.equal(true);
     });
 
-    it("can be verified by name", async () => {
+    it("can be looked up by name", async () => {
       expect(await contracts.ETSAccessControls.isRelayerByName("Uniswap")).to.be.equal(true);
+    });
+
+    it("can be locked/unlocked by Platform", async () => {
+      // Try pausing by non-administrator account.
+      const relayerAddress = await contracts.ETSAccessControls.getRelayerAddressFromName("Uniswap");
+      await expect(contracts.ETSAccessControls.connect(accounts.RandomOne).toggleRelayerLock(relayerAddress)).to.be
+        .reverted;
+
+      await expect(contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(relayerAddress))
+        .to.emit(contracts.ETSAccessControls, "RelayerLockToggled")
+        .withArgs(relayerAddress);
+
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(true);
+
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(relayerAddress);
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(false);
+    });
+
+    it("are paused by Platform if relayer is transferred to new owner with no CTAGS", async () => {
+      // TODO
+      //
+    });
+
+    it("cannot be paused by non-owner or non-relayer admin", async () => {
+      // Try pausing as non-owner (eg. RandomTwo)
+      uniswapRelayer = new ethers.Contract(relayerAddress, etsRelayerV1ABI, accounts.RandomTwo);
+      await expect(uniswapRelayer.pause()).to.be.revertedWith("Caller not relayer admin");
     });
 
     it("can be paused & unpaused by Owner", async () => {
       expect(await uniswapRelayer.paused()).to.be.equal(false);
-      expect(await uniswapRelayer.isPausedByOwner()).to.be.equal(false);
+      expect(await uniswapRelayer.isPaused()).to.be.equal(false);
 
       // Now pause as the owner
       expect(await uniswapRelayer.pause())
@@ -123,10 +177,99 @@ describe("ETSRelayerFactory Tests", function () {
         .withArgs(accounts.RandomOne.address);
     });
 
-    it("will revert if non-owner attempts to pause", async () => {
-      // Try pausing as non-owner (eg. RandomTwo)
-      uniswapRelayer2 = new ethers.Contract(relayerAddress, etsRelayerV1ABI, accounts.RandomTwo);
-      await expect(uniswapRelayer2.pause()).to.be.revertedWith("Ownable: caller is not the owner");
+    it("can be paused & unpaused by Platform (Relayer Admin)", async () => {
+      expect(await uniswapRelayer.paused()).to.be.equal(false);
+      expect(await uniswapRelayer.isPaused()).to.be.equal(false);
+
+      // Now pause as the owner
+      expect(await uniswapRelayer.connect(accounts.ETSPlatform).pause())
+        .to.emit(relayerAddress, "Paused")
+        .withArgs(accounts.ETSPlatform.address);
+
+      expect(await uniswapRelayer.connect(accounts.ETSPlatform).unpause())
+        .to.emit(relayerAddress, "Unpaused")
+        .withArgs(accounts.ETSPlatform.address);
     });
+
+    it("can be locked/unlocked by Platform", async () => {
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(false);
+
+      await expect(contracts.ETSAccessControls.connect(accounts.RandomOne).toggleRelayerLock(relayerAddress)).to.be
+        .reverted;
+
+      expect(await contracts.ETSAccessControls.toggleRelayerLock(relayerAddress))
+        .to.emit(relayerAddress, "RelayerLockToggled")
+        .withArgs(relayerAddress);
+
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(true);
+      expect(await contracts.ETSAccessControls.toggleRelayerLock(relayerAddress))
+        .to.emit(relayerAddress, "RelayerLockToggled")
+        .withArgs(relayerAddress);
+    });
+
+    it("is paused (not locked) by platform if relayer owner's CTAG balance drops to zero.", async () => {
+      expect(await contracts.ETSToken.balanceOf(accounts.RandomOne.address)).to.be.equal(2);
+      // Relayer should not be locked.
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(false);
+
+      // Transfer owned tokens so balance goes to zero
+      await contracts.ETSToken.connect(accounts.RandomOne).transferFrom(
+        accounts.RandomOne.address,
+        accounts.ETSPlatform.address,
+        tokenId,
+      );
+      await contracts.ETSToken.connect(accounts.RandomOne).transferFrom(
+        accounts.RandomOne.address,
+        accounts.ETSPlatform.address,
+        tokenId2,
+      );
+
+      expect(await contracts.ETSToken.balanceOf(accounts.RandomOne.address)).to.be.equal(0);
+      expect(await uniswapRelayer.paused()).to.be.equal(true);
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(false);
+    });
+
+    it("cannot be unpaused by owner if locked by platform", async () => {
+      // Pause as the owner
+      expect(await uniswapRelayer.pause())
+        .to.emit(relayerAddress, "Paused")
+        .withArgs(accounts.RandomOne.address);
+
+      // Verify that it's paused.
+      expect(await uniswapRelayer.paused()).to.be.equal(true);
+
+      // Now lock it at the platform level.
+      await contracts.ETSAccessControls.connect(accounts.ETSPlatform).toggleRelayerLock(relayerAddress);
+      expect(await contracts.ETSAccessControls.isRelayerLocked(relayerAddress)).to.be.equal(true);
+      await expect(uniswapRelayer.unpause()).to.be.revertedWith("Unpausing not permitted");
+    });
+
+    it("must be paused before transferring to new owner", async () => {
+      // Verify that relayer is not paused.
+      expect(await uniswapRelayer.paused()).to.be.equal(false);
+      await expect(uniswapRelayer.changeOwner(accounts.RandomTwo.address)).to.be.revertedWith("Pausable: not paused");
+      await uniswapRelayer.pause();
+      // Attempt to transfer ownership.
+      expect(await uniswapRelayer.changeOwner(accounts.RandomTwo.address))
+        .to.emit(relayerAddress, "RelayerOwnerChanged")
+        .withArgs(relayerAddress);
+    });
+
+    it("can only be transferred by current owner", async () => {
+      // Verify that relayer is not paused.
+      await uniswapRelayer.pause();
+      await expect(
+        uniswapRelayer.connect(accounts.ETSPlatform).changeOwner(accounts.RandomTwo.address),
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("when transferred should no longer belong to previous owner", async () => {
+      // Verify that relayer is not paused.
+      await uniswapRelayer.pause();
+      await uniswapRelayer.changeOwner(accounts.RandomTwo.address);
+      expect(await contracts.ETSAccessControls.isRelayerByOwner(accounts.RandomOne.address)).to.be.equal(false);
+      expect(await contracts.ETSAccessControls.isRelayerByOwner(accounts.RandomTwo.address)).to.be.equal(true);
+    });
+
   });
 });

--- a/packages/contracts/test/ETSRelayerFactory.test.js
+++ b/packages/contracts/test/ETSRelayerFactory.test.js
@@ -5,6 +5,25 @@ const { expect } = require("chai");
 describe("ETSRelayerFactory Tests", function () {
   beforeEach("Setup test", async function () {
     [accounts, contracts, initSettings] = await setup();
+
+    // Create two tags and transfer them to RandomOne so that user can add a relayer in tests.
+    const tag = "#LOVE";
+    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag]);
+    tokenId = await contracts.ETSToken.computeTagId(tag);
+    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+      accounts.ETSPlatform.address,
+      accounts.RandomOne.address,
+      tokenId,
+    );
+
+    const tag2 = "#HATE";
+    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag2]);
+    tokenId2 = await contracts.ETSToken.computeTagId(tag2);
+    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+      accounts.ETSPlatform.address,
+      accounts.RandomOne.address,
+      tokenId2,
+    );
   });
 
   describe("Valid setup/initialization", async function () {

--- a/packages/contracts/test/ETSToken.test.js
+++ b/packages/contracts/test/ETSToken.test.js
@@ -9,14 +9,6 @@ describe("ETSToken Core Tests", function () {
   // we create a setup function that can be called by every test and setup variable for easy to read tests
   beforeEach("Setup test", async function () {
     [accounts, contracts, initSettings] = await setup();
-
-    // Add & unpause ETSPlatform as a Relayer. Using a wallet address as a relayer
-    // is only for testing all ETS core public functions that don't necessarily need to be
-    // included in a proper relayer (IETSRelayer) contract
-    await contracts.ETSAccessControls.connect(accounts.ETSPlatform).addRelayer(
-      accounts.ETSPlatform.address,
-      "ETSPlatform",
-    );
   });
 
   describe("Valid setup", async function () {

--- a/packages/contracts/test/ETSUpgradeable.test.js
+++ b/packages/contracts/test/ETSUpgradeable.test.js
@@ -10,6 +10,7 @@ describe("Upgrades tests", function () {
     artifacts = await getArtifacts();
     factories = await getFactories();
     [accounts, contracts, initSettings] = await setup();
+
   });
 
   describe("ETSAccessControl", async function () {

--- a/packages/contracts/test/ETSUpgradeableRelayer.test.js
+++ b/packages/contracts/test/ETSUpgradeableRelayer.test.js
@@ -7,11 +7,21 @@ describe("Upgrades tests", function () {
     factories = await getFactories();
     [accounts, contracts, initSettings] = await setup();
 
-    // Transfer one of RandomOne's tokens to RandomTwo so RandomTwo can add a relayer.
-    const tag2 = "#HATE";
-    tokenId2 = await contracts.ETSToken.computeTagId(tag2);
-    await contracts.ETSToken.connect(accounts.RandomOne).transferFrom(
+    // Create two tags and transfer them to RandomOne so that user can add a relayer in tests.
+    const tag = "#LOVE";
+    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag]);
+    tokenId = await contracts.ETSToken.computeTagId(tag);
+    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+      accounts.ETSPlatform.address,
       accounts.RandomOne.address,
+      tokenId,
+    );
+
+    const tag2 = "#HATE";
+    await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag2]);
+    tokenId2 = await contracts.ETSToken.computeTagId(tag2);
+    await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+      accounts.ETSPlatform.address,
       accounts.RandomTwo.address,
       tokenId2,
     );

--- a/packages/contracts/test/ETSUpgradeableRelayer.test.js
+++ b/packages/contracts/test/ETSUpgradeableRelayer.test.js
@@ -4,9 +4,17 @@ let artifacts, factories;
 
 describe("Upgrades tests", function () {
   beforeEach("Setup test", async function () {
-    artifacts = await getArtifacts();
     factories = await getFactories();
     [accounts, contracts, initSettings] = await setup();
+
+    // Transfer one of RandomOne's tokens to RandomTwo so RandomTwo can add a relayer.
+    const tag2 = "#HATE";
+    tokenId2 = await contracts.ETSToken.computeTagId(tag2);
+    await contracts.ETSToken.connect(accounts.RandomOne).transferFrom(
+      accounts.RandomOne.address,
+      accounts.RandomTwo.address,
+      tokenId2,
+    );
 
     await contracts.ETSRelayerFactory.connect(accounts.RandomOne).addRelayer("Relayer 1");
     await contracts.ETSRelayerFactory.connect(accounts.RandomTwo).addRelayer("Relayer 2");
@@ -29,7 +37,7 @@ describe("Upgrades tests", function () {
       expect(await relayer1v1.version()).to.be.equal("0.1-Beta");
       expect(await relayer2v1.version()).to.be.equal("0.1-Beta");
 
-      // Connect to the beacon contract
+      // Connect to the beacon contract by platform
       etsRelayerBeacon = new ethers.Contract(beaconAddress, etsRelayerBeaconABI, accounts.ETSAdmin);
 
       // Deploy v2 relayer, and update beacon with address.

--- a/packages/contracts/test/_ETSPrintSettings.test.js
+++ b/packages/contracts/test/_ETSPrintSettings.test.js
@@ -1,8 +1,4 @@
 const { setup } = require("./setup.js");
-const { ethers } = require("hardhat");
-const { expect, assert } = require("chai");
-const { constants } = ethers;
-
 //let accounts, factories, contracts.ETSAccessControls, ETSLifeCycleControls, contracts.ETSToken;
 let targetURI;
 
@@ -10,6 +6,11 @@ describe("============= ETS TEST SUITE SETTINGS =============", function () {
   // we create a setup function that can be called by every test and setup variable for easy to read tests
   it("is running with the preceding settings", async function () {
     [accounts, contracts, initSettings] = await setup();
+    console.log("======================== ROLES ============================");
+    console.log("RELAYER_ROLE", await contracts.ETSAccessControls.RELAYER_ROLE());
+    console.log("RELAYER_FACTORY_ROLE", await contracts.ETSAccessControls.RELAYER_FACTORY_ROLE());
+    console.log("RELAYER_ADMIN_ROLE", await contracts.ETSAccessControls.RELAYER_ADMIN_ROLE());
+    console.log("SMART_CONTRACT_ROLE", await contracts.ETSAccessControls.SMART_CONTRACT_ROLE());
     console.log("======================== ACCOUNTS ============================");
     console.log("ETSAdmin:", accounts.ETSAdmin.address);
     console.log("ETSPlatform:", accounts.ETSPlatform.address);
@@ -25,6 +26,8 @@ describe("============= ETS TEST SUITE SETTINGS =============", function () {
     console.log("ETSTarget:", contracts.ETSTarget.address);
     console.log("ETSEnrichTarget:", contracts.ETSEnrichTarget.address);
     console.log("ETS:", contracts.ETS.address);
+    console.log("ETSRelayerFactory:", contracts.ETSRelayerFactory.address);
+    console.log("ETSRelayerImplementation:", contracts.ETSRelayerImplementation.address);
     console.log("ETSRelayer:", contracts.ETSRelayer.address);
     console.log("======================== INIT SETTINGS ============================");
     console.log(initSettings);

--- a/packages/contracts/test/setup.js
+++ b/packages/contracts/test/setup.js
@@ -175,12 +175,18 @@ async function setup() {
 
   // ============ GRANT ROLES & APPROVALS ============
 
-  // Grant RELAYER_ADMIN role to ETSRelayerFactory so it can deploy relayer contracts.
-  await ETSAccessControls.grantRole(ethers.utils.id("RELAYER_ADMIN"), ETSRelayerFactory.address);
+  // Allows relayer admin role to grant relayer factory role.
+  await ETSAccessControls.setRoleAdmin(await ETSAccessControls.RELAYER_FACTORY_ROLE(), await ETSAccessControls.RELAYER_ADMIN_ROLE());
 
-  await ETSAccessControls.grantRole(await ETSAccessControls.SMART_CONTRACT_ROLE(), accounts.ETSAdmin.address, {
-    from: accounts.ETSAdmin.address,
-  });
+  // Allows relayer factory role to grant relayer role.
+  await ETSAccessControls.setRoleAdmin(await ETSAccessControls.RELAYER_ROLE(), await ETSAccessControls.RELAYER_FACTORY_ROLE());
+
+  await ETSAccessControls.grantRole(await ETSAccessControls.RELAYER_ADMIN_ROLE(), accounts.ETSAdmin.address);
+  await ETSAccessControls.grantRole(await ETSAccessControls.RELAYER_ADMIN_ROLE(), accounts.ETSPlatform.address);
+  await ETSAccessControls.grantRole(await ETSAccessControls.RELAYER_ADMIN_ROLE(), ETSAccessControls.address);
+  await ETSAccessControls.grantRole(await ETSAccessControls.RELAYER_ADMIN_ROLE(), ETSToken.address);
+
+  await ETSAccessControls.grantRole(await ETSAccessControls.SMART_CONTRACT_ROLE(), accounts.ETSAdmin.address);
 
   await ETSTarget.connect(accounts.ETSPlatform).setEnrichTarget(ETSEnrichTarget.address);
 
@@ -190,7 +196,10 @@ async function setup() {
   // Set ETS Core on ETSToken.
   await ETSToken.connect(accounts.ETSPlatform).setETSCore(ETS.address);
 
-  // Add a relayer proxy for use in tests.
+  // Grant RELAYER_FACTORY_ROLE to ETSRelayerFactory so it can deploy relayer contracts.
+  await ETSAccessControls.grantRole(await ETSAccessControls.RELAYER_FACTORY_ROLE(), ETSRelayerFactory.address);
+
+  // Add a relayer proxy for use in tests. Note: ETSPlatform not required to own CTAG to add relayer.
   await ETSRelayerFactory.connect(accounts.ETSPlatform).addRelayer("ETSRelayer");
   relayerAddress = await ETSAccessControls.getRelayerAddressFromName("ETSRelayer");
   etsRelayerV1ABI = require("../abi/contracts/relayers/ETSRelayerV1.sol/ETSRelayerV1.json");

--- a/packages/contracts/test/setup.js
+++ b/packages/contracts/test/setup.js
@@ -204,25 +204,6 @@ async function setup() {
   relayerAddress = await ETSAccessControls.getRelayerAddressFromName("ETSRelayer");
   etsRelayerV1ABI = require("../abi/contracts/relayers/ETSRelayerV1.sol/ETSRelayerV1.json");
   contracts.ETSRelayer = new ethers.Contract(relayerAddress, etsRelayerV1ABI, accounts.RandomOne);
-
-  // Create two tags and transfer them to RandomOne so that user can add a relayer in tests.
-  const tag = "#LOVE";
-  await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag]);
-  tokenId = await contracts.ETSToken.computeTagId(tag);
-  await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
-    accounts.ETSPlatform.address,
-    accounts.RandomOne.address,
-    tokenId,
-  );
-
-  const tag2 = "#HATE";
-  await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag2]);
-  tokenId2 = await contracts.ETSToken.computeTagId(tag2);
-  await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
-    accounts.ETSPlatform.address,
-    accounts.RandomOne.address,
-    tokenId2,
-  );
   return [accounts, contracts, initSettings];
 }
 

--- a/packages/contracts/test/setup.js
+++ b/packages/contracts/test/setup.js
@@ -205,6 +205,24 @@ async function setup() {
   etsRelayerV1ABI = require("../abi/contracts/relayers/ETSRelayerV1.sol/ETSRelayerV1.json");
   contracts.ETSRelayer = new ethers.Contract(relayerAddress, etsRelayerV1ABI, accounts.RandomOne);
 
+  // Create two tags and transfer them to RandomOne so that user can add a relayer in tests.
+  const tag = "#LOVE";
+  await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag]);
+  tokenId = await contracts.ETSToken.computeTagId(tag);
+  await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+    accounts.ETSPlatform.address,
+    accounts.RandomOne.address,
+    tokenId,
+  );
+
+  const tag2 = "#HATE";
+  await contracts.ETSRelayer.connect(accounts.RandomTwo).getOrCreateTagIds([tag2]);
+  tokenId2 = await contracts.ETSToken.computeTagId(tag2);
+  await contracts.ETSToken.connect(accounts.ETSPlatform).transferFrom(
+    accounts.ETSPlatform.address,
+    accounts.RandomOne.address,
+    tokenId2,
+  );
   return [accounts, contracts, initSettings];
 }
 


### PR DESCRIPTION
resolves gh-232

When a user tries to add a relayer, protocol now check that sender owns at least one CTAG. I could have made this number configurable, but decided against it in the interest of simplicity.

Additional features/checks:

1. If relayer owner transfers CTAGs away and their balance goes to zero, the protocol will pause their relayer. 
2. If relayer owner tries to unpause their relayer, protocol checks CTAG balance and only permits if balance is > 0.
3. System checks that relayer is paused before owner can transfer relayer to new owner.
4. Protocol now has a way to lookup relayer by relayer owner. eg. given relayer owner address, return the relayer address. This by nature, enforces that one address can only own one relayer.
5. Only relayer owner may transfer a relayer to a new owner.
6. Renamed platform "pausing" to platform "locking" to describe the functionality whereby the platform can lock a relayer. 