### PR TITLE
Include contracts in contracts package

### DIFF
--- a/.changeset/perfect-boats-taste.md
+++ b/.changeset/perfect-boats-taste.md
@@ -1,0 +1,5 @@
+---
+"@ethereum-tag-service/contracts": patch
+---
+
+Remove /src, include /contracts in package

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -57,7 +57,7 @@
   "main": "./dist/multiChainConfig.js",
   "module": "./dist/multiChainConfig.mjs",
   "types": "./dist/multiChainConfig.d.ts",
-  "files": ["dist", "src"],
+  "files": ["dist", "contracts"],
   "scripts": {
     "build": "pnpm build:package",
     "build:contracts": "pnpm compile",


### PR DESCRIPTION
resolves #483

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on restructuring the `@ethereum-tag-service/contracts` package by removing the `/src` directory and enhancing the documentation for the Ethereum Tag Service (ETS). It introduces the `IETSRelayer` interface for improved tagging functionality.

### Detailed summary
- Updated `package.json` to include `/contracts` instead of `/src`.
- Revised the `README.md` to clarify ETS features and installation instructions.
- Added a section on implementing a `Relayer` with the `IETSRelayer` interface.
- Modified the example contract to utilize `IETSRelayer` instead of `IETSPublisherV1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->