### PR TITLE
Fix sync-stage workflow.

### DIFF
--- a/.github/workflows/sync-stage.yml
+++ b/.github/workflows/sync-stage.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Sync main to stage
         run: |
-          git fetch origin stage:stage
+          git fetch origin main:main stage:stage
           git checkout stage
           git merge origin/main
           git push origin stage


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow in the `.github/workflows/sync-stage.yml` file to fetch both the `main` and `stage` branches from the `origin` repository before merging changes.

### Detailed summary
- Updated the `git fetch` command to fetch both `main` and `stage` branches: `git fetch origin main:main stage:stage` instead of just `git fetch origin stage:stage`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->