### PR TITLE
Fix bad blockchain explorer links

### DIFF
--- a/apps/app/components/Navigation.tsx
+++ b/apps/app/components/Navigation.tsx
@@ -30,7 +30,7 @@ export default function Navigation() {
                   d="M0 50 50 0H0v50zm100 50V50l-50 50h50zM50 0l50 50V0H50zM19.9 84.9c0 2.8-2.2 5-5 5s-5-2.2-5-5 2.2-5 5-5 5 2.3 5 5z"
                 />
               </svg>
-              <span className="hidden md:inline-flex ml-2.5 text-3xl font-medium text-slate-900">ETS</span>
+              <span className="ml-2.5 text-3xl font-medium text-slate-900">ETS</span>
               <span className="ml-2 font-thin">explorer</span>
               <h1 className="sr-only">ETS</h1>
             </div>

--- a/apps/app/components/SiteMessage.tsx
+++ b/apps/app/components/SiteMessage.tsx
@@ -38,7 +38,8 @@ const SiteMessage: React.FC = () => {
           <Image src={iconPath} alt={`${chainName} icon`} width={24} height={24} className="mr-3" />
           <div>
             <h3 className="text-lg">
-              Welcome to <span className="font-bold">ETS</span> on <span className="font-bold">{displayName}</span>
+              Welcome to the <span className="font-semibold">ETS Explorer</span> on{" "}
+              <span className="font-semibold">{displayName}</span>
             </h3>
             <div className="text-sm">{t("testnet-warning")}</div>
           </div>

--- a/apps/app/components/TaggingRecords.tsx
+++ b/apps/app/components/TaggingRecords.tsx
@@ -48,7 +48,7 @@ const TaggingRecords: NextPage<Props> = ({
       target: columnHelper.accessor("target.id", {
         header: t("target"),
         cell: (info) => (
-          <Address href={`/explore/targets/${info.getValue()}`} address={info.getValue()} addressType="long-id" />
+          <Address href={`/explore/targets/${info.getValue()}`} address={info.getValue()} explorerLink={false} />
         ),
       }),
       tags: columnHelper.accessor("tags", {

--- a/apps/app/hooks/useExplorerUrl.ts
+++ b/apps/app/hooks/useExplorerUrl.ts
@@ -2,14 +2,22 @@ import { useEnvironmentContext } from "@app/context/EnvironmentContext";
 import { getChainInfo } from "@app/utils/getChainInfo";
 import { getExplorerUrl as getExplorerUrlUtil } from "@ethereum-tag-service/contracts/utils";
 import { useMemo } from "react";
-type ExplorerUrlType = "tx" | "address" | "token" | "nft";
 
 export const useExplorerUrl = () => {
   const { network } = useEnvironmentContext();
   const chainInfo = useMemo(() => getChainInfo(network), [network]);
-  const getExplorerUrl = (type: ExplorerUrlType = "tx", hash?: string): string => {
-    return getExplorerUrlUtil(chainInfo.chain.id, type, hash);
+
+  const getNftUrl = (tokenId?: string) => {
+    return getExplorerUrlUtil(chainInfo.chain.id, "nft", tokenId);
   };
 
-  return getExplorerUrl;
+  const getAddressUrl = (address?: string) => {
+    return getExplorerUrlUtil(chainInfo.chain.id, "address", address);
+  };
+
+  const getTxnUrl = (hash?: string) => {
+    return getExplorerUrlUtil(chainInfo.chain.id, "tx", hash);
+  };
+
+  return { getNftUrl, getAddressUrl, getTxnUrl };
 };

--- a/apps/app/pages/explore/ctags/[id].tsx
+++ b/apps/app/pages/explore/ctags/[id].tsx
@@ -95,7 +95,7 @@ const Tag: NextPage = () => {
             <div className="font-semibold">{t("id")}</div>
             <div className="flex space-x-1">
               <div className="grid flex-grow md:grid-flow-col justify-end">
-                <Address address={safeTag.id} addressType="long-id" />
+                <Address address={safeTag.id} type="nft" />
               </div>
             </div>
           </div>

--- a/apps/app/pages/explore/tagging-records/[id].tsx
+++ b/apps/app/pages/explore/tagging-records/[id].tsx
@@ -34,7 +34,7 @@ const TaggingRecord: NextPage = () => {
                 <div className="grid grid-cols-3 px-6 py-4 md:grid-flow-col hover:bg-slate-100">
                   <div className="font-semibold">{t("id")}</div>
                   <div className="col-span-2 text-left">
-                    <Address address={taggingRecord.id} />
+                    <Address address={taggingRecord.txnHash} type="txn" />
                   </div>
                 </div>
 
@@ -73,9 +73,9 @@ const TaggingRecord: NextPage = () => {
                   <div className="font-semibold">{t("target-id")}</div>
                   <div className="flex space-x-1 col-span-2 justify-start">
                     <Address
-                      address={taggingRecord.target.id}
-                      addressType="long-id"
+                      address={`${taggingRecord.target.id}`}
                       href={`/explore/targets/${taggingRecord.target.id}`}
+                      explorerLink={false}
                     />
                   </div>
                 </div>
@@ -83,9 +83,10 @@ const TaggingRecord: NextPage = () => {
                   <div className="font-semibold">{t("target-uri")}</div>
                   <div className="flex col-span-2 justify-start">
                     <Address
-                      addressType="url"
+                      type="url"
                       address={taggingRecord.target.targetURI}
                       href={taggingRecord.target.targetURI}
+                      explorerLink={false}
                     />
                   </div>
                 </div>
@@ -107,5 +108,4 @@ const TaggingRecord: NextPage = () => {
     </Layout>
   );
 };
-
 export default TaggingRecord;

--- a/apps/app/pages/explore/targets/[id].tsx
+++ b/apps/app/pages/explore/targets/[id].tsx
@@ -31,7 +31,7 @@ const Target: NextPage = () => {
                 <div className="grid grid-cols-3 px-6 py-4 md:grid-flow-col hover:bg-slate-100">
                   <div className="font-semibold">{t("id")}</div>
                   <div className=" col-span-2 text-left">
-                    <Address address={targets?.[0].id} addressType="long-id" />
+                    <Address address={targets?.[0].id} explorerLink={false} />
                   </div>
                 </div>
 
@@ -47,7 +47,7 @@ const Target: NextPage = () => {
                   <div className="flex col-span-2 justify-start">
                     <Address
                       address={targets?.[0].targetURI}
-                      addressType="url"
+                      type="url"
                       href={targets?.[0].targetURI}
                       explorerLink={false}
                     />

--- a/apps/app/pages/explore/targets/index.tsx
+++ b/apps/app/pages/explore/targets/index.tsx
@@ -25,7 +25,7 @@ const Targets: NextPage = () => {
         cell: (info) => {
           const target = info.row.original as any;
           return (
-            target.id && <Address address={target.id} addressType="long-id" href={`/explore/targets/${target.id}`} />
+            target.id && <Address address={target.id} href={`/explore/targets/${target.id}`} explorerLink={false} />
           );
         },
       }),
@@ -37,7 +37,7 @@ const Targets: NextPage = () => {
         header: t("URI"),
         cell: (info) => (
           <div className="flex items-center">
-            <Address address={info.getValue()} addressType="url" href={info.getValue()} explorerLink={false} />
+            <Address address={info.getValue()} type="url" href={info.getValue()} explorerLink={false} />
           </div>
         ),
       }),

--- a/apps/app/pages/index.tsx
+++ b/apps/app/pages/index.tsx
@@ -71,7 +71,8 @@ const Home: NextPage = () => {
                 d="M0 50 50 0H0v50zm100 50V50l-50 50h50zM50 0l50 50V0H50zM19.9 84.9c0 2.8-2.2 5-5 5s-5-2.2-5-5 2.2-5 5-5 5 2.3 5 5z"
               />
             </svg>
-            <span className="inline-flex ml-2.5 text-xl font-medium text-slate-900">Ethereum Tag Service</span>
+            <span className="hidden md:inline-flex ml-2.5 text-3xl font-medium text-slate-900">ETS</span>
+            <span className="ml-2 font-thin">explorer</span>
           </div>
 
           <ChainModalETS show={true} onClose={() => {}} asModal={false} />


### PR DESCRIPTION
resolves #482

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating the `Address` component to improve its functionality and appearance across various pages and components. It refines address handling by introducing new types and modifying existing props for better clarity and usability.

### Detailed summary
- Changed `addressType` prop to `type` in the `Address` component with new types: `"address"`, `"nft"`, `"txn"`, and `"url"`.
- Updated instances of the `Address` component to use the new `type` prop.
- Removed the `addressType` prop from the `Address` component interface.
- Modified several pages (`[id].tsx`, `index.tsx`, etc.) to reflect changes in the `Address` component.
- Enhanced the `useExplorerUrl` hook to return specific functions for each URL type (`getNftUrl`, `getAddressUrl`, `getTxnUrl`).
- Updated the `SiteMessage` component to change the welcome text to "ETS Explorer".
- Removed unnecessary comments and documentation from the `Address` component.
- Adjusted the display logic for the `Address` component to improve tooltip handling and link behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->